### PR TITLE
Use to zola to build the site

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,23 @@
+# Master
 [build]
-  publish = "public"
-  command = "curl -sL https://github.com/Keats/gutenberg/releases/download/v0.3.1/gutenberg-v0.3.1-x86_64-unknown-linux-gnu.tar.gz | tar zxvf - && /opt/build/repo/gutenberg build"
+command = "zola build"
+publish = "public"
 
+[context.production.environment]
+ZOLA_VERSION = "0.15.3"
+
+
+# Merge requests
 [context.deploy-preview]
-  command = "curl -sL https://github.com/Keats/gutenberg/releases/download/v0.3.1/gutenberg-v0.3.1-x86_64-unknown-linux-gnu.tar.gz | tar zxvf - && /opt/build/repo/gutenberg build --base-url $DEPLOY_PRIME_URL"
+command = "zola build --base-url $DEPLOY_PRIME_URL"
+
+[context.deploy-preview.environment]
+ZOLA_VERSION = "0.15.3"
+
+
+# Branches
+[context.branch-deploy]
+command = "zola build --base-url $DEPLOY_PRIME_URL"
+
+[context.branch-deploy.environment]
+ZOLA_VERSION = "0.15.3"


### PR DESCRIPTION
Gutenberg has been rebranded to zola ages ago.